### PR TITLE
Compromise: allow some cookie IDs for fraud & anonymized dataset construction

### DIFF
--- a/dnt-policy-discussion-draft2.txt
+++ b/dnt-policy-discussion-draft2.txt
@@ -37,26 +37,40 @@ listed below:
 1. END USER IDENTIFIERS:         
 
   a. If a DNT User has logged in to our service, all user identifiers, such as
-     unique or nearly unique cookies, "supercookies" and fingerprints are 
-     discarded as soon as the HTTP(S) response is issued.                                    
+     unique or nearly unique cookies, "supercookies" and fingerprints do not
+     persist on our servers for more than 72 hours after an HTTP(S) response is
+     issued.
 
      Data structures which associate user identifiers with accounts may be
      employed to recognize logged in users per Exception 4 below, but may not
      be associated with records of the user's activities unless otherwise
      excepted.
 
-  b. If a DNT User is not logged in to our service, we will take steps to ensure 
-     that no user identifiers are transmitted to us at all.         
+  b. If a DNT User is not logged in to our service, we will take steps to
+     ensure that no non-cookie user identifiers are transmitted to us at all;
+     and if we send or receive unique cookies, we will:
+
+     i.   Ensure that such cookies do not persist in browsers for longer than
+          72 hours, and that our systems do not routinely link past
+          values of these cookies to subsequent values.
+
+     ii.  Limit the use of unique cookies to the purposes covered by the
+          Exceptions below.
+
+     iii. Understand that some users or client software may decide to block
+          these cookies, and where possible ensure that user-facing
+          functionality is unaffected by cookie blocking or deletion.
 
 2. LOG RETENTION: 
 
   a. Logs with DNT Users' identifiers removed (but including IP addresses and
      User Agent strings) may be retained for a period of 10 days or less,
-     unless an Exception (below) applies. This period of time balances privacy
-     concerns with the need to ensure that log processing systems have time to
-     operate; that operations engineers have time to monitor and fix technical
-     and performance problems; and that security and data aggregation systems
-     have time to operate.
+     unless an Exception (below) applies. Cookie values may be retained in
+     logs for a period of 72 hours or less.  These periods of time balances 
+     privacy concerns with the need to ensure that log processing systems have 
+     time to operate; that operations engineers have time to monitor and fix
+     technical and performance problems; and that security and data aggregation
+     systems have time to operate.
 
   b. These logs will not be used for any other purposes.         
 
@@ -80,10 +94,10 @@ listed below:
      employ a contractual commitment from the recipient to respect this policy
      for our DNT Users' data.
 
-    NOTE: if an “Other Domain” does not receive identifiable user information
-    from the domain because such information has been removed, because the
-    Other Domain does not log that information, or for some other reason, these
-    requirements do not apply.
+     NOTE: if an “Other Domain” does not receive identifiable user information
+     from the domain because such information has been removed, because the
+     Other Domain does not log that information, or for some other reason, these
+     requirements do not apply.
 
   c. "Identfiable" means any records which are not Anonymized or otherwise
      covered by the Exceptions below.
@@ -151,12 +165,13 @@ the following specific situations:
 
 3. TECHNICAL AND SECURITY LOGGING:                   
 
-  a. If, during the processing of the initial request (for unique identifiers)
-     or during the subsequent 10 days (for IP addresses and User Agent strings),
-     we obtain specific information that causes our employees or systems to
-     believe that a request is, or is likely to be, part of a security attack,
-     spam submission, or fraudulent transaction, then logs of those requests 
-     are not subject to this policy.                                   
+  a. If, during the processing of the initial request (for non-cookie unique
+     identifiers), the subsequent 72 hours (for unique cookies) or during the
+     subsequent 10 days (for IP addresses and User Agent strings), we obtain
+     specific information that causes our employees or systems to believe that
+     a request is, or is likely to be, part of a security attack, spam
+     submission, or fraudulent transaction, then logs of those requests are
+     not subject to this policy.                                   
 
   b. If we encounter technical problems with our site, then, in rare
      circumstances, we may retain logs for longer than 10 days, if that is


### PR DESCRIPTION
- Only cookie IDs are allowed
- With strict time limits (72 hours)
- And usage limits
- And tolerance of cookie blocking