### PR TITLE
Keep lf line-endings when working with git

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = false
+insert_final_newline = true
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This may help with #22 in some scenarios and was recently discussed at EFForg/PrivacyBadger#2946 while everything seems OK in this repository (`git add --renormalize .` sees no changes).

However there is a large amount of trailing whitespaces that may be confusing if anyone is looking to implement dnt-policy using `.editorconfig` or text editor that otherwise trims trailing whitespace in addition to looking bad.

- https://github.com/EFForg/dnt-policy/commit/b855fdf8c7bfc7ee4be2c5d3cd68d1803de34e08